### PR TITLE
Update Inspire 2019 test rules to match previous year

### DIFF
--- a/resource/build2019-prod/session_map.json
+++ b/resource/build2019-prod/session_map.json
@@ -43,7 +43,7 @@
     {
       "HubbId": 2637,
       "SessionTypeName": "Pre-Record",
-      "SessionSets": []
+      "SessionSets": ["Schedule Builder"]
     },
     {
       "HubbId": 2639,

--- a/resource/inspire2019-test/sidebarMetadata.json
+++ b/resource/inspire2019-test/sidebarMetadata.json
@@ -42,7 +42,7 @@
         "title": "Products",
         "layout": "link",
         "listings": "leafNodeFilters",
-        "subtype": "products",
+        "subtype": "product",
         "subMetadata": []
       },
       {


### PR DESCRIPTION
This at least gets us running for 2019 sign in - task card 60368 captures work for updating for 2019 access grid.