### PR TITLE
remove obsolete meetings opt in for Ignite2019

### DIFF
--- a/resource/ignite2019-prod/profileMetadataDetails.json
+++ b/resource/ignite2019-prod/profileMetadataDetails.json
@@ -163,14 +163,6 @@
             "Value": ""
           },
           {
-            "DisplayTitle": "translate.profile.label.can-attend-meetings",
-            "FieldName": "CanAttendMeetings",
-            "Style": "checkbox",
-            "Class": "",
-            "Path": "optins.canAttendMeetings",
-            "Value": ""
-          },
-          {
             "DisplayTitle": "translate.profile.label.is-publicly-visible",
             "FieldName": "IsPubliclyVisible",
             "Style": "checkbox",

--- a/resource/ignite2019-test/profileMetadataDetails.json
+++ b/resource/ignite2019-test/profileMetadataDetails.json
@@ -163,14 +163,6 @@
             "Value": ""
           },
           {
-            "DisplayTitle": "translate.profile.label.can-attend-meetings",
-            "FieldName": "CanAttendMeetings",
-            "Style": "checkbox",
-            "Class": "",
-            "Path": "optins.canAttendMeetings",
-            "Value": ""
-          },
-          {
             "DisplayTitle": "translate.profile.label.is-publicly-visible",
             "FieldName": "IsPubliclyVisible",
             "Style": "checkbox",


### PR DESCRIPTION
remove obsolete meetings opt in for Ignite2019
now the "CanBeFound" opt-in determines both whether attendee is in attendee directory, and if they are, they are automatically opt-ed into meetings/messaging